### PR TITLE
Fix minor bugs in candidates

### DIFF
--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -98,7 +98,11 @@ def test_fixed_window(centered_pair_predictions):
         track_matching_method="greedy",
     )
     tracked_instances = tracker.track_frame(pred_instances, 0)
-    assert tracker.candidate.current_tracks == ["0", "1"]
+    assert len(tracker.candidate.current_tracks) == 2
+    assert (
+        "0" in tracker.candidate.current_tracks
+        and "1" in tracker.candidate.current_tracks
+    )
     assert (
         tracked_instances[0].track.name == "track_0"
         and tracked_instances[1].track.name == "track_1"

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -73,7 +73,11 @@ def test_local_queue(centered_pair_predictions):
     for inst in tracked_instances:
         assert inst.track is not None
     assert len(tracker.candidate.tracker_queue) == 2
-    assert tracker.candidate.current_tracks == ["0", "1"]
+    assert len(tracker.candidate.current_tracks) == 2
+    assert (
+        "0" in tracker.candidate.current_tracks
+        and "1" in tracker.candidate.current_tracks
+    )
     assert (
         tracked_instances[0].track.name == "0"
         and tracked_instances[1].track.name == "1"


### PR DESCRIPTION
This PR addresses a few bugs in the tracking module:

- `Fixed Window`:
Previously, the current_tracks attribute stored all track IDs created so far. However, `current_tracks` should only include the track IDs of instances currently present in the tracker queue.

- `Local Queue`:
When the `max_tracks` limit is reached, unmatched instances should be assigned track = `None`. These instances should be excluded from the final LabeledFrame (per SLEAP behavior).